### PR TITLE
Better forgetful recurrent network changes

### DIFF
--- a/pybrain/structure/modules/module.py
+++ b/pybrain/structure/modules/module.py
@@ -1,6 +1,6 @@
 __author__ = 'Daan Wierstra and Tom Schaul'
 
-from scipy import zeros
+from scipy import append, zeros
 
 from pybrain.utilities import abstractMethod, Named
 
@@ -85,6 +85,21 @@ class Module(Named):
         for buffername, l  in self.bufferlist:
             buf = getattr(self, buffername)
             buf[:] = zeros(l)
+
+    def shift(self, items):
+        """Shift all buffers up or down a defined number of items on offset axis.
+        Negative values indicate backward shift."""
+        if items == 0:
+            return
+        self.offset += items
+        for buffername, l  in self.bufferlist:
+            buf = getattr(self, buffername)
+            assert abs(items) <= len(buf), "Cannot shift further than length of buffer."
+            fill = zeros((abs(items), len(buf[0])))
+            if items < 0:
+                buf[:] = append(buf[-items:], fill, 0)
+            else:
+                buf[:] = append(fill ,buf[0:-items] , 0)
 
     def activateOnDataset(self, dataset):
         """Run the module's forward pass on the given dataset unconditionally

--- a/pybrain/structure/networks/recurrent.py
+++ b/pybrain/structure/networks/recurrent.py
@@ -15,13 +15,10 @@ class RecurrentNetworkComponent(object):
 
     sequential = True
 
-    def __init__(self, forget, name=None, *args, **kwargs):
+    def __init__(self, forget=None, name=None, *args, **kwargs):
         self.recurrentConns = []
         self.maxoffset = 0
-        if forget:
-           self.increment = 0
-        else:
-           self.increment = 1
+        self.forget = forget
 
     def __str__(self):
         s = super(RecurrentNetworkComponent, self).__str__()
@@ -51,26 +48,29 @@ class RecurrentNetworkComponent(object):
         """Do one transformation of an input and return the result."""
         self.inputbuffer[self.offset] = inpt
         self.forward()
-        return self.outputbuffer[self.offset - self.increment].copy()
+        if self.forget:
+            return self.outputbuffer[self.offset].copy()
+        else:
+            return self.outputbuffer[self.offset - 1].copy()
 
     def backActivate(self, outerr):
         """Do one transformation of an output error outerr backward and return
         the error on the input."""
-        self.outputerror[self.offset - self.increment] = outerr
+        self.outputerror[self.offset - 1] = outerr
         self.backward()
         return self.inputerror[self.offset].copy()
 
     def forward(self):
         """Produce the output from the input."""
-        if not (self.offset + self.increment < self.inputbuffer.shape[0]):
+        if not (self.offset + 1 < self.inputbuffer.shape[0]):
             self._growBuffers()
         super(RecurrentNetworkComponent, self).forward()
-        self.offset += self.increment
+        self.offset += 1
         self.maxoffset = max(self.offset, self.maxoffset)
 
     def backward(self):
         """Produce the input error from the output error."""
-        self.offset -= self.increment
+        self.offset -= 1
         super(RecurrentNetworkComponent, self).backward()
 
     def _isLastTimestep(self):
@@ -78,6 +78,9 @@ class RecurrentNetworkComponent(object):
 
     def _forwardImplementation(self, inbuf, outbuf):
         assert self.sorted, ".sortModules() has not been called"
+
+        if self.forget:
+            self.offset += 1
 
         index = 0
         offset = self.offset
@@ -87,12 +90,18 @@ class RecurrentNetworkComponent(object):
 
         if offset > 0:
             for c in self.recurrentConns:
-                c.forward(offset - self.increment, offset)
+                c.forward(offset - 1, offset)
 
         for m in self.modulesSorted:
             m.forward()
             for c in self.connections[m]:
                 c.forward(offset, offset)
+
+        if self.forget:
+            for m in self.modules:
+                m.shift(-1)
+            offset -= 1
+            self.offset -= 2
 
         index = 0
         for m in self.outmodules:
@@ -100,6 +109,7 @@ class RecurrentNetworkComponent(object):
             index += m.outdim
 
     def _backwardImplementation(self, outerr, inerr, outbuf, inbuf):
+        assert not self.forget, "Cannot back propagate a forgetful network"
         assert self.sorted, ".sortModules() has not been called"
         index = 0
         offset = self.offset
@@ -109,7 +119,7 @@ class RecurrentNetworkComponent(object):
 
         if not self._isLastTimestep():
             for c in self.recurrentConns:
-                c.backward(offset, offset + self.increment)
+                c.backward(offset, offset + 1)
 
         for m in reversed(self.modulesSorted):
             for c in self.connections[m]:


### PR DESCRIPTION
Previous approach did not give synchronous updates, resulting in bad behaviour. This approach propagates forward as for the normal RecurrentNetwork and then shifts time backwards (a bit uglier than that since the original looks back for recurrent connection, so we have to jump forward to look back and then shift back further after we have finished - I'd be happy if someone can see a nicer approach).
