### PR TITLE
Using splitWithProportion on large data sets is time consuming

### DIFF
--- a/pybrain/datasets/supervised.py
+++ b/pybrain/datasets/supervised.py
@@ -102,7 +102,7 @@ class SupervisedDataSet(DataSet):
     def splitWithProportion(self, proportion = 0.5):
         """Produce two new datasets, the first one containing the fraction given
         by `proportion` of the samples."""
-        leftIndices = sample(range(len(self)), int(len(self)*proportion))
+        leftIndices = set(sample(range(len(self)), int(len(self)*proportion)))
         leftDs = self.copy()
         leftDs.clear()
         rightDs = leftDs.copy()


### PR DESCRIPTION
Using splitWithProportion in e.g. ClassificationDataSet took forever. This seems to have been caused by checking "if _element_ in _list_", which is far from optimal when the data set has over a million samples in it.

I changed the random sample list which is used so that it instead is a set. Granted, this does increase the memory footprint, but I think this is preferable for most people.

The speed-up using a set appears to be quite substantial. The old method using a list did not complete in several hours, whereas the new method only used a few seconds.
