### PR TITLE
Renamed README.TXT to README.md for proper markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+PyBrain -- the Python Machine Learning Library
+===============================================
+
+
+INSTALLATION
+------------
+Quick answer: make sure you have SciPy installed, then
+	python setup.py install
+	
+Longer answer: (if the above was any trouble) we keep more
+detailed installation instructions (including those
+for the dependencies) up-to-date in a wiki at:
+	http://wiki.github.com/pybrain/pybrain/installation
+
+
+DOCUMENTATION
+-------------
+Please read
+	docs/documentation.pdf
+or browse
+	docs/html/*	
+featuring: quickstart, tutorials, API, etc.
+
+If you have matplotlib, the scripts in
+	examples/*
+may be instructive as well.
+


### PR DESCRIPTION
README.TXT was showing improper markdown, renaming it to README.md fixed that so it shows up properly
on the homepage.
It was two commits because I didn't double check my 'git commit' before sending... It's fine though.
