### PR TITLE
doc: warn about unimplemented args in RL explorer

### DIFF
--- a/pybrain/rl/explorers/discrete/discretesde.py
+++ b/pybrain/rl/explorers/discrete/discretesde.py
@@ -16,6 +16,9 @@ class DiscreteStateDependentExplorer(DiscreteExplorer):
     """
 
     def __init__(self, epsilon = 0.2, decay = 0.9998):
+        """ TODO: the epsilon and decay parameters are currently
+            not implemented.
+        """
         DiscreteExplorer.__init__(self)
         self.state = None
 


### PR DESCRIPTION
This isn't a real fix to the unimplemented parameters, but a warning like this would have saved me 30 minutes this morning.  :)
