### PR TITLE
Q, SARSA: ignore 1st triple in episodic training

### DIFF
--- a/pybrain/rl/learners/valuebased/q.py
+++ b/pybrain/rl/learners/valuebased/q.py
@@ -35,6 +35,12 @@ class Q(ValueBasedLearner):
             samples = [[self.dataset.getSample()]]
 
         for seq in samples:
+            # information from the previous episode (sequence)
+            # should not influence the training on this episode
+            self.laststate = None
+            self.lastaction = None
+            self.lastreward = None
+
             for state, action, reward in seq:
 
                 state = int(state)

--- a/pybrain/rl/learners/valuebased/sarsa.py
+++ b/pybrain/rl/learners/valuebased/sarsa.py
@@ -31,6 +31,11 @@ class SARSA(ValueBasedLearner):
             samples = [[self.dataset.getSample()]]
 
         for seq in samples:
+            # information from the previous episode (sequence)
+            # should not influence the training on this episode
+            self.laststate = None
+            self.lastaction = None
+            self.lastreward = None
             for state, action, reward in seq:
 
                 state = int(state)


### PR DESCRIPTION
When training multiple episodes (with learnOnDataset and
batchMode=True), the final iteration of episode n-1 should not
affect the first iteration of episode n.
