### PR TITLE
Fix: Networkwriter saves now recurrent connections of arac networks

### DIFF
--- a/pybrain/tools/customxml/networkwriter.py
+++ b/pybrain/tools/customxml/networkwriter.py
@@ -62,7 +62,7 @@ class NetworkWriter(XMLHandling):
         for m in net.modulesSorted:
             for c in net.connections[m]:
                 self.writeConnection(conns, c, False)
-        if isinstance(net, RecurrentNetwork):
+        if hasattr(net, "recurrentConns"):
             for c in net.recurrentConns:
                 self.writeConnection(conns, c, True)
 


### PR DESCRIPTION
When using arac (fast) recurrent networks and saving them with the NetworWriter module to a xml the recurrent connections get lost. This is caused by the check to a specific pybrain class. As arac has other class instances the condition doesn't match although there are recurrent connections. 
Now the condition is changed to check if the network has recurrentmodules instead of a class instance check. 
