### PR TITLE
Fix incompatibilities with Python 3

### DIFF
--- a/pybrain/datasets/sequential.py
+++ b/pybrain/datasets/sequential.py
@@ -1,7 +1,13 @@
 __author__ = 'Thomas Rueckstiess, ruecksti@in.tum.de'
 # $Id$
 
-from itertools import izip
+try:
+    # Python 2
+    from itertools import izip
+except ImportError:
+    # Python 3
+    izip = zip
+
 from scipy import ravel, r_
 from random import sample
 

--- a/pybrain/supervised/trainers/backprop.py
+++ b/pybrain/supervised/trainers/backprop.py
@@ -3,6 +3,7 @@ __author__ = 'Daan Wierstra and Tom Schaul'
 from scipy import dot, argmax
 from random import shuffle
 from math import isnan
+from functools import reduce
 from pybrain.supervised.trainers.trainer import Trainer
 from pybrain.utilities import fListToString
 from pybrain.auxiliary import GradientDescent

--- a/pybrain/tools/datasets/mnist.py
+++ b/pybrain/tools/datasets/mnist.py
@@ -3,6 +3,11 @@ import os
 import scipy
 import struct
 
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip
+
 from pybrain.datasets import SupervisedDataSet
 
 
@@ -42,7 +47,7 @@ def makeMnistDataSets(path):
     test_images = images(test_image_file)
     test_labels = (flaggedArrayByIndex(l, 10) for l in labels(test_label_file))
 
-    for image, label in itertools.izip(test_images, test_labels):
+    for image, label in izip(test_images, test_labels):
         test.addSample(image, label)
 
     train = SupervisedDataSet(28 * 28, 10)
@@ -50,7 +55,7 @@ def makeMnistDataSets(path):
     train_label_file = os.path.join(path, 'train-labels-idx1-ubyte')
     train_images = images(train_image_file)
     train_labels = (flaggedArrayByIndex(l, 10) for l in labels(train_label_file))
-    for image, label in itertools.izip(train_images, train_labels):
+    for image, label in izip(train_images, train_labels):
         train.addSample(image, label)
 
     return train, test


### PR DESCRIPTION
I tried to use BackpropTrainer and ClassificationDataSet with Python 3 and hit a couple of syntax errors due to incompatibility. This pull request adds Python 2/3 compatible code for izip and reduce.
