### PR TITLE
Fixed math errors in the cart pole simulation

### DIFF
--- a/pybrain/rl/environments/cartpole/cartpole.py
+++ b/pybrain/rl/environments/cartpole/cartpole.py
@@ -84,9 +84,9 @@ class CartPoleEnvironment(GraphicalEnvironment):
         mp = self.mp
         mc = self.mc
         l = self.l
-        u_ = (self.g * sin_theta * (mc + mp) - (F + mp * l * theta ** 2 * sin_theta) * cos_theta) / (4 / 3 * l * (mc + mp) - mp * l * cos_theta ** 2)
+        u_ = (self.g * sin_theta * (mc + mp) - (F + mp * l * theta_ ** 2 * sin_theta) * cos_theta) / (4 / 3 * l * (mc + mp) - mp * l * cos_theta ** 2)
         v = s_
-        v_ = (F - mp * l * (u_ * cos_theta - (s_ ** 2 * sin_theta))) / (mc + mp)
+        v_ = (F - mp * l * (u_ * cos_theta - (theta_ ** 2 * sin_theta))) / (mc + mp)
         return (u, u_, v, v_)
 
     def getPoleAngles(self):


### PR DESCRIPTION
I was playing with the code from the cart pole simulator (trying to create my own simulator based on it), and I discovered what I believe are some serious math typos.

Assuming I am not in error, these changes should give the correct equations, you guys can verify this by looking at the paper "Evaluation of Policy Gradient Methods and Variants on the Cart-Pole Benchmark" in the appendix section, with the correct equations. From the comments, I assume these equations were originally typed up from that paper, but the code simply had typos.

Another paper to look at is "Correct equations for the dynamics of the cart-pole system" 2007 Florian, Razvan V.

I also subjectively verified this version feels correct by creating a "game" type simulation with keyboard input. The other (incorrect) equations would usually behave very oddly, and the pendulum would sometimes balance itself with little user input. With the fixes, it (subjectively) seems to behave exactly as a cart-pole system should behave.