### PR TITLE
Fix incompatibility with Python 3 using //

### DIFF
--- a/pybrain/supervised/trainers/backprop.py
+++ b/pybrain/supervised/trainers/backprop.py
@@ -158,7 +158,7 @@ class BackpropTrainer(Trainer):
         if verbose:
             print(('Average error:', avgErr))
             print(('Max error:', max(ponderatedErrors), 'Median error:',
-                   sorted(ponderatedErrors)[len(errors) / 2]))
+                   sorted(ponderatedErrors)[len(errors) // 2]))
         return avgErr
 
     def testOnClassData(self, dataset=None, verbose=False,


### PR DESCRIPTION
Add python 2 and 3 compatibility by using the floor division operator '//'.
Cf. https://docs.python.org/2/whatsnew/2.2.html#pep-238-changing-the-division-operator