### PR TITLE
splitWithProportion works now for different dataset classes

### DIFF
--- a/pybrain/datasets/supervised.py
+++ b/pybrain/datasets/supervised.py
@@ -111,9 +111,10 @@ class SupervisedDataSet(DataSet):
         leftIndicies = indicies[:separator]
         rightIndicies = indicies[separator:]
 
-        leftDs = SupervisedDataSet(inp=self['input'][leftIndicies].copy(),
+        datasetClass = self.__class__
+        leftDs = datasetClass(inp=self['input'][leftIndicies].copy(),
                                    target=self['target'][leftIndicies].copy())
-        rightDs = SupervisedDataSet(inp=self['input'][rightIndicies].copy(),
+        rightDs = datasetClass(inp=self['input'][rightIndicies].copy(),
                                     target=self['target'][rightIndicies].copy())
         return leftDs, rightDs
 


### PR DESCRIPTION
I fixed an issue: When doing `splitWithProportion` on a `ClassificationDataSet`, the resulting datasets has been of type `SupervisedDataSet `:

	from pybrain.datasets import ClassificationDataSet
	ds = ClassificationDataSet(100, 1)
	print type(ds) # <class 'pybrain.datasets.classification.ClassificationDataSet'>
	tstdata, trndata = ds.splitWithProportion(0.25)
	print type(tstdata) # <class 'pybrain.datasets.supervised.SupervisedDataSet'>
	print type(trndata) # <class 'pybrain.datasets.supervised.SupervisedDataSet'>
	tstdata._convertToOneOfMany() # error

This is because `ClassificationDataSet` inherits its method `splitWithProportion` from `SupervisedDataSet`. So I fixed this by dynamically detecting the class of `self` in the attribute, and instantiating these classes.

Related: http://stackoverflow.com/questions/27887936/attributeerror-using-pybrain-splitwithportion-object-type-changed