### PR TITLE
fix validation.CrossValidator.validate(), use test_ds

### DIFF
--- a/pybrain/tools/validation.py
+++ b/pybrain/tools/validation.py
@@ -328,7 +328,7 @@ class CrossValidator(object):
             test_ds.setField("input"  , inp[test_idxs])
             test_ds.setField("target" , tar[test_idxs])
 #            perf += self.getPerformance( trainer.module, dataset )
-            perf += self._calculatePerformance(trainer.module, dataset)
+            perf += self._calculatePerformance(trainer.module, test_ds)
 
         perf /= n_folds
         return perf


### PR DESCRIPTION
I'm no expert, but I think test_ds should be used here.