### PR TITLE
splitWithProportion returns same type instead of SupervisedDataSet

### DIFF
--- a/pybrain/datasets/supervised.py
+++ b/pybrain/datasets/supervised.py
@@ -111,9 +111,9 @@ class SupervisedDataSet(DataSet):
         leftIndicies = indicies[:separator]
         rightIndicies = indicies[separator:]
 
-        leftDs = SupervisedDataSet(inp=self['input'][leftIndicies].copy(),
+        leftDs = type(self)(inp=self['input'][leftIndicies].copy(),
                                    target=self['target'][leftIndicies].copy())
-        rightDs = SupervisedDataSet(inp=self['input'][rightIndicies].copy(),
+        rightDs = type(self)(inp=self['input'][rightIndicies].copy(),
                                     target=self['target'][rightIndicies].copy())
         return leftDs, rightDs
 


### PR DESCRIPTION
When we call splitWithProportion on a ClassificationDataSet object, return type is (SupervisedDataSet, SupervisedDataSet) instead of (ClassificationDataSet, ClassificationDataSet). While this modification fixes this issue, it can be improved by calling the constructor using kwargs.  Didn't modify sub-classes in order to prevent repetition of lines 106-112. I've done this modification because when we split a sub-class of SupervisedDataSet, we should get a 2-tuple of sub-class object. Not a 2-tuple of SupervisedDataSet.