### PR TITLE
[MRG] Fix splitWithProportion output class bug #197

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: nosetests

--- a/pybrain/datasets/supervised.py
+++ b/pybrain/datasets/supervised.py
@@ -111,9 +111,8 @@ class SupervisedDataSet(DataSet):
         leftIndicies = indicies[:separator]
         rightIndicies = indicies[separator:]
 
-        leftDs = SupervisedDataSet(inp=self['input'][leftIndicies].copy(),
+        leftDs = type(self)(inp=self['input'][leftIndicies].copy(),
                                    target=self['target'][leftIndicies].copy())
-        rightDs = SupervisedDataSet(inp=self['input'][rightIndicies].copy(),
+        rightDs = type(self)(inp=self['input'][rightIndicies].copy(),
                                     target=self['target'][rightIndicies].copy())
         return leftDs, rightDs
-


### PR DESCRIPTION
- bug evident at http://pybrain.org/docs/tutorial/fnn.html
- alldata = ClassificationDataSet(blah, blah,...)
- trndata, tstdata = alldata.splitWithProportion(0.25)
- trndata._convertToOneOfMany( ) -->
  AttributeError: 'SupervisedDataSet' object has no attribute
  '_convertToOneOfMany'
- trndata is SupervdedDataSet, not ClassificationDataSet like parent
- SupervisedDataSet has no method _convertToOneOfMany( )
- splitWithProportion method now returns same class as parent
