### PR TITLE
 expm2 has been modified as _expm_frechet

### DIFF
--- a/pybrain/tools/functions.py
+++ b/pybrain/tools/functions.py
@@ -1,7 +1,7 @@
 __author__ = 'Tom Schaul, tom@idsia.ch'
 
 from scipy import array, exp, tanh, clip, log, dot, sqrt, power, pi, tan, diag, rand, real_if_close
-from scipy.linalg import inv, det, svd, logm, expm
+from scipy.linalg import inv, det, svd, logm, _expm_frechet
 
 
 def semilinear(x):


### PR DESCRIPTION
Scipy latest version doesn't contain scipy.linalg.expm2. Instead, it has scipy.linalg._expm_frechet