### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pybrain/rl/environments/flexcube/viewer.py
+++ b/pybrain/rl/environments/flexcube/viewer.py
@@ -103,7 +103,7 @@ class FlexCubeRenderer(object):
         else: sleep(self.dt)
           
     def drawScene(self):
-        ''' This methode describes the complete scene.'''
+        ''' This method describes the complete scene.'''
         # clear the buffer
         if self.zDis < 10: self.zDis += 0.25
         if self.lastz > 200: self.lastz -= self.zDis

--- a/pybrain/rl/environments/ode/tasks/ccrl.py
+++ b/pybrain/rl/environments/ode/tasks/ccrl.py
@@ -15,7 +15,7 @@ class CCRLTask(EpisodicTask):
         self.maxPower = 100.0
         self.reward_history = []
         self.count = 0 #timestep counter
-        self.epiLen = 1500 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 1500 #suggested episodic length for normal Johnnie tasks
         self.incLearn = 0 #counts the task resets for incrementall learning
         self.env.FricMu = 20.0 #We need higher friction for CCRL
         self.env.dt = 0.002 #We also need more timly resolution
@@ -42,7 +42,7 @@ class CCRLTask(EpisodicTask):
         self.env.addSensor(SpecificBodyPositionSensor(['fingerLeft2'], "finger2Pos"))
         #we changed sensors so we need to update environments sensorLength variable
         self.env.obsLen = len(self.env.getSensors())
-        #normalization for the task spezific sensors
+        #normalization for the task specific sensors
         for i in range(self.env.obsLen - 2 * self.env.actLen):
             self.sensor_limits.append((-4, 4))
         self.actor_limits = None
@@ -111,7 +111,7 @@ class CCRLGlasTask(CCRLTask):
     def __init__(self, env):
         CCRLTask.__init__(self, env)
         self.dif = array([0.0, 0.0, 0.0])
-        self.epiLen = 1000 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 1000 #suggested episodic length for normal Johnnie tasks
 
     def isFinished(self):
         #returns true if episode timesteps has reached episode length and resets the task
@@ -141,7 +141,7 @@ class CCRLPlateTask(CCRLTask):
     def __init__(self, env):
         CCRLTask.__init__(self, env)
         self.dif = array([0.0, 0.2, 0.8])
-        self.epiLen = 1000 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 1000 #suggested episodic length for normal Johnnie tasks
 
     def isFinished(self):
         #returns true if episode timesteps has reached episode length and resets the task
@@ -172,7 +172,7 @@ class CCRLPlateTask(CCRLTask):
 class CCRLGlasVarTask(CCRLGlasTask):
     def __init__(self, env):
         CCRLGlasTask.__init__(self, env)
-        self.epiLen = 5000 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 5000 #suggested episodic length for normal Johnnie tasks
 
     def isFinished(self):
         #returns true if episode timesteps has reached episode length and resets the task
@@ -227,7 +227,7 @@ class CCRLGlasVarRandTask(CCRLGlasVarTask):
 class CCRLPointTask(CCRLGlasVarTask):
     def __init__(self, env):
         CCRLGlasVarTask.__init__(self, env)
-        self.epiLen = 1000 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 1000 #suggested episodic length for normal Johnnie tasks
 
     def isFinished(self):
         #returns true if episode timesteps has reached episode length and resets the task
@@ -291,7 +291,7 @@ class CCRLPointTask(CCRLGlasVarTask):
 class CCRLPointVarTask(CCRLPointTask):
     def __init__(self, env):
         CCRLPointTask.__init__(self, env)
-        self.epiLen = 2000 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 2000 #suggested episodic length for normal Johnnie tasks
 
     def isFinished(self):
         #returns true if episode timesteps has reached episode length and resets the task

--- a/pybrain/rl/environments/ode/tasks/johnnie.py
+++ b/pybrain/rl/environments/ode/tasks/johnnie.py
@@ -11,7 +11,7 @@ class JohnnieTask(EpisodicTask):
         self.maxPower = 100.0 #Overall maximal tourque - is multiplied with relative max tourque for individual joint to get individual max tourque
         self.reward_history = []
         self.count = 0 #timestep counter
-        self.epiLen = 500 #suggestet episodic length for normal Johnnie tasks
+        self.epiLen = 500 #suggested episodic length for normal Johnnie tasks
         self.incLearn = 0 #counts the task resets for incrementall learning
         self.env.FricMu = 20.0 #We need higher friction for Johnnie
         self.env.dt = 0.01 #We also need more timly resolution
@@ -58,7 +58,7 @@ class JohnnieTask(EpisodicTask):
 class StandingTask(JohnnieTask):
     def __init__(self, env):
         JohnnieTask.__init__(self, env)
-        #add task spezific sensors, TODO build attitude sensors
+        #add task specific sensors, TODO build attitude sensors
         self.env.addSensor(SpecificBodyPositionSensor(['footLeft'], "footLPos"))
         self.env.addSensor(SpecificBodyPositionSensor(['footRight'], "footRPos"))
         self.env.addSensor(SpecificBodyPositionSensor(['palm'], "bodyPos"))
@@ -67,14 +67,14 @@ class StandingTask(JohnnieTask):
         #we changed sensors so we need to update environments sensorLength variable
         self.env.obsLen = len(self.env.getSensors())
 
-        #normalization for the task spezific sensors
+        #normalization for the task specific sensors
         for _ in range(self.env.obsLen - 2 * self.env.actLen):
             self.sensor_limits.append((-20, 20))
         self.epiLen = 1000 #suggested episode length for this task
 
     def getReward(self):
         # calculate reward and return reward
-        reward = self.env.getSensorByName('headPos')[1] / float(self.epiLen) #reward is hight of head
+        reward = self.env.getSensorByName('headPos')[1] / float(self.epiLen) #reward is height of head
         #to prevent jumping reward can't get bigger than head position while standing absolut upright
         reward = clip(reward, -14.0, 4.0)
         return reward
@@ -128,7 +128,7 @@ class RobustStandingTask(RobStandingTask):
 class JumpingTask(JohnnieTask):
     def __init__(self, env):
         JohnnieTask.__init__(self, env)
-        #add task spezific sensors, TODO build attitude sensors
+        #add task specific sensors, TODO build attitude sensors
         self.env.addSensor(SpecificBodyPositionSensor(['footLeft']))
         self.env.addSensor(SpecificBodyPositionSensor(['footRight']))
         self.env.addSensor(SpecificBodyPositionSensor(['palm']))
@@ -137,16 +137,16 @@ class JumpingTask(JohnnieTask):
         #we changed sensors so we need to update environments sensorLength variable
         self.env.obsLen = len(self.env.getSensors())
 
-        #normalization for the task spezific sensors
+        #normalization for the task specific sensors
         for _ in range(self.env.obsLen - 2 * self.env.actLen):
             self.sensor_limits.append((-20, 20))
         self.epiLen = 400 #suggested episode length for this task
-        self.maxHight = 4.0 #maximum hight reached during episode
+        self.maxHight = 4.0 #maximum height reached during episode
         self.maxPower = 400.0 #jumping needs more power
 
     def getReward(self):
         # calculate reward and return reward
-        reward = self.env.getSensorByName('SpecificBodyPositionSensor8')[1] #reward is hight of head
+        reward = self.env.getSensorByName('SpecificBodyPositionSensor8')[1] #reward is height of head
         if reward > self.maxHight:
             self.maxHight = reward
         if self.count == self.epiLen:
@@ -174,7 +174,7 @@ class StandingUpTask(StandingTask):
         if self.count < 800:
             return 0.0
         else:
-            reward = self.env.getSensorByName('SpecificBodyPositionSensor8')[1] / float(self.epiLen - 800) #reward is hight of head
+            reward = self.env.getSensorByName('SpecificBodyPositionSensor8')[1] / float(self.epiLen - 800) #reward is height of head
             #to prevent jumping reward can't get bigger than head position while standing absolut upright
             reward = clip(reward, -14.0, 4.0)
             return reward

--- a/pybrain/rl/environments/shipsteer/viewer.py
+++ b/pybrain/rl/environments/shipsteer/viewer.py
@@ -103,7 +103,7 @@ class FlexCubeRenderer(object):
         else: sleep(self.dt)
 
     def drawScene(self):
-        ''' This methode describes the complete scene.'''
+        ''' This method describes the complete scene.'''
         # clear the buffer
         if self.zDis < 10: self.zDis += 0.25
         if self.lastz > 100: self.lastz -= self.zDis

--- a/pybrain/structure/modules/lstm.py
+++ b/pybrain/structure/modules/lstm.py
@@ -76,7 +76,7 @@ class LSTMLayer(NeuronLayer, ParameterContainer):
 
 
     def _isLastTimestep(self):
-        """Tell wether the current offset is the maximum offset."""
+        """Tell whether the current offset is the maximum offset."""
         return self.maxoffset == self.offset
 
     def _forwardImplementation(self, inbuf, outbuf):

--- a/pybrain/tests/runtests.py
+++ b/pybrain/tests/runtests.py
@@ -22,7 +22,7 @@ def setUpLogging():
 
 
 def testImport(module_name):
-    """Tell wether a module can be imported.
+    """Tell whether a module can be imported.
 
     This function has a cache, so modules are only tested once on
     importability.

--- a/pybrain/tools/rlgluebridge.py
+++ b/pybrain/tools/rlgluebridge.py
@@ -102,7 +102,7 @@ class RlglueAgentAdapter(object):
         :type task_specification:   string
         """
         # This is (for now) actually a dummy method to satisfy the
-        # RLGlue interface. It is the programmer's job to check wether an
+        # RLGlue interface. It is the programmer's job to check whether an
         # experiment fits the agent object.
         self.agent.reset()
 


### PR DESCRIPTION
There are small typos in:
- pybrain/rl/environments/flexcube/viewer.py
- pybrain/rl/environments/ode/tasks/ccrl.py
- pybrain/rl/environments/ode/tasks/johnnie.py
- pybrain/rl/environments/shipsteer/viewer.py
- pybrain/structure/modules/lstm.py
- pybrain/tests/runtests.py
- pybrain/tools/rlgluebridge.py

Fixes:
- Should read `suggested` rather than `suggestet`.
- Should read `specific` rather than `spezific`.
- Should read `height` rather than `hight`.
- Should read `whether` rather than `wether`.
- Should read `method` rather than `methode`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md